### PR TITLE
Change red background at bottom of the page to light grey.

### DIFF
--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -486,7 +486,6 @@ a:focus{
 }
 
 .callout.secondary{
-  background-color: $dred;
   margin-bottom: 0px;
   padding: 20px 30px 30px 30px;
 }
@@ -534,7 +533,7 @@ a:focus{
 h5{
   font-weight: 500;
   font-size: 1em;
-  color: darken(white, 15%);
+  color: $dgrey;
   margin-bottom:10px;
 }
 


### PR DESCRIPTION
This makes the logos clearer, as requested in #80.

Here are screenshots of the change on desktop and mobile:
![desktop](https://user-images.githubusercontent.com/4331931/47100998-df223d80-d206-11e8-9e18-f7325129dff1.png)
![mobile](https://user-images.githubusercontent.com/4331931/47101002-e2b5c480-d206-11e8-8a6e-748bea3b9e91.png)
