### PR TITLE
Append readable name to state and jurisdiction URLs.

### DIFF
--- a/app/scripts/components/map.js
+++ b/app/scripts/components/map.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import d3 from 'd3';
 const topojson = require('topojson');
+import { getUrlName } from '../utils';
 
 function MapClass (el, states) {
   this.$el = d3.select(el);
@@ -36,7 +37,8 @@ function MapClass (el, states) {
 
       if (_id) {
         this.states[_id] = {
-          'id': states[i].id
+          'id': states[i].id,
+          'name': states[i].name
         };
         if (states[i].is_active) {
           this.states[_id].fill = '#a55873';
@@ -94,7 +96,8 @@ function MapClass (el, states) {
 
   this.click = (d) => {
     if (d.id in this.states) {
-      window.location.href = `/states/${this.states[d.id].id}`;
+      const urlName = getUrlName(this.states[d.id].name);
+      window.location.href = `/states/${this.states[d.id].id}/${urlName}`;
     }
   };
 

--- a/app/scripts/components/search.js
+++ b/app/scripts/components/search.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Autosuggest from 'react-autosuggest';
 import { updateInputValue, loadSuggestions, cleanSuggestions } from '../actions';
+import { getUrlName } from '../utils';
 
 function getSuggestionValue (suggestion) {
   if (suggestion.type === 'jurisdiction') {
@@ -39,7 +40,8 @@ class Search extends React.Component {
 
   onSuggestionSelected (event, context) {
     if (!context.suggestion.noLink) {
-      this.props.history.push(`/j/${context.suggestion.id}`);
+      const urlName = getUrlName(context.suggestion.name);
+      this.props.history.push(`/j/${context.suggestion.id}/${urlName}`);
     }
   }
 

--- a/app/scripts/utils.js
+++ b/app/scripts/utils.js
@@ -57,3 +57,10 @@ export function shape (el, geojson) {
     .style('fill', '#ccc')
     .style('stroke-width', '1');
 }
+
+export function getUrlName (name) {
+  if (!name) {
+    return '';
+  }
+  return name.replace(/[^a-zA-Z0-9]+/g, '-');
+}

--- a/app/scripts/views/state.js
+++ b/app/scripts/views/state.js
@@ -12,6 +12,7 @@ import Shape from '../components/shape';
 import NotFound from './404';
 import MoreInfo from '../components/results/info';
 import { fetchStateJurisdictions, fetchStates } from '../actions';
+import { getUrlName } from '../utils';
 
 class State extends React.Component {
   getStateId () {
@@ -48,8 +49,9 @@ class State extends React.Component {
         const jurs = stateJurisdictions[stateObj.id];
         for (const i in jurs) {
           const obj = jurs[i];
+          const urlName = getUrlName(obj.name);
           if (obj.name) {
-            list.push(<div className = 'select-link' key={obj.id}><p><Link to={`/j/${obj.id}`}>{obj.name}</Link></p></div>);
+            list.push(<div className = 'select-link' key={obj.id}><p><Link to={`/j/${obj.id}/${urlName}`}>{obj.name}</Link></p></div>);
           }
         }
       } else {

--- a/app/scripts/views/states.js
+++ b/app/scripts/views/states.js
@@ -8,6 +8,7 @@ import Loader from 'react-loader';
 import Box from '../components/box';
 import Map from '../components/map';
 import { fetchStates } from '../actions';
+import { getUrlName } from '../utils';
 
 class States extends React.Component {
   getId (id) {
@@ -18,6 +19,10 @@ class States extends React.Component {
     } else {
       return 0;
     }
+  }
+
+  getUrlStateName (name) {
+    return name.replace(/[^a-zA-Z0-9]+/g, '-');
   }
 
   componentDidMount () {
@@ -34,7 +39,8 @@ class States extends React.Component {
 
     for (const i in states) {
       const obj = states[i];
-      list.push(<Link to={`/states/${obj.id}`}><div className = 'select-link' key={obj.id}><p key={obj.id}>{obj.name}</p></div></Link>);
+      const urlName = getUrlName(states[i].name);
+      list.push(<Link to={`/states/${obj.id}/${urlName}`}><div className = 'select-link' key={obj.id}><p key={obj.id}>{obj.name}</p></div></Link>);
     }
     map = <Map data={states} />;
 


### PR DESCRIPTION
This pull request addresses https://github.com/developmentseed/work.vote/issues/99 and https://github.com/developmentseed/work.vote/issues/100.

It appends a readable name to URLs for state and jurisdictions. This is a similar approach to the one used by the site stackoverflow.com. It gives us readable names without having to redirect old URLs. Both of the following pairs of URLs go to the same place:

* https://www.workelections.com/states/1, https://www.workelections.com/states/1/Alabama
* https://www.workelections.com/j/3531, https://www.workelections.com/j/3531/Marengo-County

So this pull request just changes the URLs in the UI to use the format that appends the state/jurisdiction name. @nayelipelayo FYI.