### PR TITLE
Add training_note parameter for jurisdictions

### DIFF
--- a/app/scripts/views/jurisdiction.js
+++ b/app/scripts/views/jurisdiction.js
@@ -147,7 +147,6 @@ class Jurisdiction extends React.Component {
                   <span></span>
                 </Otherwise>
               </Choose>
-
               <Choose>
                 <When condition={ jurisdiction.complete_training === 'Y' }>
                   <li><p>You must complete training for each election.</p></li>
@@ -158,6 +157,12 @@ class Jurisdiction extends React.Component {
                 <Otherwise>
                   <span></span>
                 </Otherwise>
+              </Choose>
+              <Choose>
+                <When condition={ jurisdiction.training_note }>
+                  <li><p>{`Training Details: ${jurisdiction.training_note}`}</p></li>
+                </When>
+                <Otherwise><span /></Otherwise>
               </Choose>
             </ul>
 


### PR DESCRIPTION
In question 17 in the surveys, a person can respond with additional training notes. However, our backend picks up two keys with "question 17" in the key name, and so doesn't distinguish between the boolean "Is there a training" and "Please specify notes".

This is the frontend part of the solution where we add a training_note parameter coming in from the backend.