### PR TITLE
Change language for application

### DIFF
--- a/app/scripts/components/application.js
+++ b/app/scripts/components/application.js
@@ -71,13 +71,13 @@ class Application extends React.Component {
 
     return (
       <vote-application>
-        <div className='text-header'>Application</div>
+        <div className='text-header'>Statement of Interest</div>
 
         <div className={calloutClassError} name='error'>
           <p>{errorMessage}</p>
         </div>
 
-        <p><em>This application generates an email that is sent to the local election official for your city or county. Workelections.com does not retain your personal information.</em></p>
+        <p><em>This form generates an email that is sent to the local election official for your city or county. Workelections.com does not retain your personal information.</em></p>
 
         <label>
           First Name:<span className='red'>*</span>
@@ -132,7 +132,7 @@ class Application extends React.Component {
           />
         </label>
 
-        <div className='btn' onClick={this.submitForm}>Submit</div><span className={submitLabel} name='label'>Sending... Please wait!</span>
+        <div className='btn' onClick={this.submitForm}>Send</div><span className={submitLabel} name='label'>Sending... Please wait!</span>
 
         <p><span className='red'>* are required</span></p>
 

--- a/app/scripts/components/results/apply.js
+++ b/app/scripts/components/results/apply.js
@@ -41,7 +41,7 @@ class Apply extends React.Component {
       );
     } else {
       return (
-        <a href='#' onClick={this.clicked}><div className='btn'>Apply Now!</div></a>
+        <a href='#' onClick={this.clicked}><div className='btn'>Contact Your Local Election Office</div></a>
       );
     }
   }


### PR DESCRIPTION
It is ok for the Apply Now! button to remain as is if the jurisdiction has a URL in that field. If it is empty but has an email address, can the button be changed to Contact Your Local Election Office?

Instead of saying "submit your application" we could say "submit your statement of interest" and encourage people to follow up with their local election office if they don't hear back.